### PR TITLE
Create backend to whitelist @mozilla.com emails.

### DIFF
--- a/plugincheck/base/auth.py
+++ b/plugincheck/base/auth.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import Group
+
+from django_browserid.auth import BrowserIDBackend
+
+
+class OnlyMozillaBackend(BrowserIDBackend):
+    """Backend that only allows *@mozilla.com emails to join.
+
+    They get is_staff bit by default.
+    """
+    def create_user(self, email):
+        if email.endswith('@mozilla.com'):
+            # Set the username to the part of the email address before the @
+            username = email.split('@')[0]
+
+            # Create the user
+            user = self.User.objects.create_user(username, email)
+
+            # Set the staff bit
+            user.is_staff = True
+            user.save()
+
+            # Add to administrators group
+            user.groups.add(Group.objects.get(name='administrators'))
+
+            return user
+
+        return None

--- a/plugincheck/settings.py
+++ b/plugincheck/settings.py
@@ -96,7 +96,7 @@ STATIC_URL = '/static/'
 
 
 AUTHENTICATION_BACKENDS = (
-   'django_browserid.auth.BrowserIDBackend',
+   'plugincheck.base.auth.OnlyMozillaBackend',
 )
 
 LOGIN_REDIRECT_URL = '/admin/'


### PR DESCRIPTION
@Osmose Does this look right? The login is always failing on the initial sign in when the account gets created, then works from there on. Have you seen that before?
